### PR TITLE
Make compatible with GHC 9.2

### DIFF
--- a/Text/Parsec/Expr.hs
+++ b/Text/Parsec/Expr.hs
@@ -91,7 +91,7 @@ type OperatorTable s u m a = [[Operator s u m a]]
 -- >  prefix  name fun       = Prefix (do{ reservedOp name; return fun })
 -- >  postfix name fun       = Postfix (do{ reservedOp name; return fun })
 
-buildExpressionParser :: (Stream s m t)
+buildExpressionParser :: (Show t, Stream s m t)
                       => OperatorTable s u m a
                       -> ParsecT s u m a
                       -> ParsecT s u m a

--- a/Text/Parsec/Free.hs
+++ b/Text/Parsec/Free.hs
@@ -30,6 +30,9 @@ instance Alternative (ParsecDSL s u m) where
     empty = parserZero
     (<|>) = parserPlus
 
+instance MonadFail (ParsecDSL s u m) where
+    fail _ = parserZero
+
 instance MonadPlus (ParsecDSL s u m) where
     mzero = parserZero
     mplus = parserPlus

--- a/Text/Parsec/Free/Eval.hs
+++ b/Text/Parsec/Free/Eval.hs
@@ -11,7 +11,7 @@ import qualified "parsec" Text.Parsec.Combinator as P
 import                    Text.Parsec.Free
 import qualified "parsec" Text.Parsec.Prim as P
 
-eval' :: forall s u m t a. P.Stream s m t
+eval' :: forall s u m t a. (Show t, P.Stream s m t)
       => (forall u' b c. Bool -> ParsecF s u' m c -> P.ParsecT s u m b
               -> P.ParsecT s u m b)
       -> (forall u' b c. Show b => Bool -> ParsecF s u' m c -> P.ParsecT s u m b
@@ -149,5 +149,5 @@ eval' h hS ind = go True
             PcommaSep p k          -> h b z (ind True (go b p)) >>= k
             PcommaSep1 p k         -> h b z (ind True (go b p)) >>= k
 
-eval :: forall s u m t a. P.Stream s m t => ParsecDSL s u m a -> P.ParsecT s u m a
+eval :: forall s u m t a. (Show t, P.Stream s m t) => ParsecDSL s u m a -> P.ParsecT s u m a
 eval = eval' (const (const id)) (const (const id)) (const id)

--- a/Text/Parsec/Prim.hs
+++ b/Text/Parsec/Prim.hs
@@ -174,24 +174,24 @@ manyAccum :: (a -> [a] -> [a])
           -> ParsecT s u m [a]
 manyAccum = F.manyAccum
 
-runPT :: (Monad m, Stream s m t)
+runPT :: (Monad m, Show t, Stream s m t)
       => ParsecT s u m a -> u -> SourceName -> s -> m (Either ParseError a)
 runPT = P.runPT . F.eval
 
-runPTLog :: (MonadIO m, MonadReader F.LogType m, Stream s m t)
+runPTLog :: (MonadIO m, MonadReader F.LogType m, Show t, Stream s m t)
          => ParsecT s u m a -> u -> SourceName -> s
          -> m (Either ParseError a)
 runPTLog = P.runPT . F.evalLog
 
-runP :: (Stream s Identity t)
+runP :: (Show t, Stream s Identity t)
      => Parsec s u a -> u -> SourceName -> s -> Either ParseError a
 runP p u n s = runIdentity $ P.runPT (F.eval p) u n s
 
-runParserT :: (Stream s m t)
+runParserT :: (Show t, Stream s m t)
            => ParsecT s u m a -> u -> SourceName -> s -> m (Either ParseError a)
 runParserT = runPT
 
-runParserTLog :: (MonadIO m, MonadReader F.LogType m, Stream s m t)
+runParserTLog :: (MonadIO m, MonadReader F.LogType m, Show t, Stream s m t)
               => ParsecT s u m a
               -> u
               -> SourceName
@@ -199,15 +199,15 @@ runParserTLog :: (MonadIO m, MonadReader F.LogType m, Stream s m t)
               -> m (Either ParseError a)
 runParserTLog = runPTLog
 
-runParser :: (Stream s Identity t)
+runParser :: (Show t, Stream s Identity t)
           => Parsec s u a -> u -> SourceName -> s -> Either ParseError a
 runParser = runP
 
-parse :: (Stream s Identity t)
+parse :: (Show t, Stream s Identity t)
       => Parsec s () a -> SourceName -> s -> Either ParseError a
 parse p = runP p ()
 
-parseTest :: (Stream s Identity t, Show a)
+parseTest :: (Show t, Stream s Identity t, Show a)
           => Parsec s () a -> s -> IO ()
 parseTest p input
     = case parse p "" input of
@@ -215,7 +215,7 @@ parseTest p input
                        print err
         Right x  -> print x
 
-parseTestLog' :: (MonadIO m, MonadReader F.LogType m, Stream s m t, Show a)
+parseTestLog' :: (MonadIO m, MonadReader F.LogType m, Show t, Stream s m t, Show a)
               => ParsecT s () m a -> s -> m ()
 parseTestLog' p input = do
     eres <- runPTLog p () "" input
@@ -224,7 +224,7 @@ parseTestLog' p input = do
                        print err
         Right x -> print x
 
-parseTestLog :: (Stream s (ReaderT F.LogType IO) t, Show a)
+parseTestLog :: (Show t, Stream s (ReaderT F.LogType IO) t, Show a)
              => Bool -- ^ If True, display every parse, not just the interesting ones
              -> ParsecT s () (ReaderT F.LogType IO) a -> s -> IO ()
 parseTestLog b p input = do


### PR DESCRIPTION
It looks like constraint resolution works differently in newer GHC versions. In order to make parsec-free work with my version (9.2.2), I resolved all compilation errors as directly as possible, as I wasn't sure how you would like the MonadReader constraints to be specified for the ParsecF types.